### PR TITLE
Fix #18: Add cli option to exec code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
  "syn_derive",
 ]
 
@@ -487,9 +487,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -502,7 +502,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 dependencies = [
  "jobserver",
  "libc",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
@@ -972,9 +972,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encode_unicode"
@@ -1000,7 +1000,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1011,11 +1011,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b73807008a3c7f171cc40312f37d95ef0396e048b5848d775f54b1a4dd4a0d3"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
 dependencies = [
  "serde",
+ "typeid",
 ]
 
 [[package]]
@@ -1242,7 +1243,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1351,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -1488,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -1710,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libflate"
@@ -1793,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1913,7 +1914,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1940,9 +1941,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
 ]
@@ -2664,9 +2665,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "open"
-version = "5.1.2"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449f0ff855d85ddbf1edd5b646d65249ead3f5e422aaa86b7d2d0b049b103e32"
+checksum = "2eb49fbd5616580e9974662cb96a3463da4476e649a7e4b258df0de065db0657"
 dependencies = [
  "is-wsl",
  "libc",
@@ -2696,7 +2697,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -2856,7 +2857,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3419,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
@@ -3634,7 +3635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3705,7 +3706,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -3825,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.3.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb78f46d0066053d16d4ca7b898e9343bc3530f71c61d5ad84cd404ada068745"
+checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3836,22 +3837,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.3.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91ac2a3c6c0520a3fb3dd89321177c3c692937c4eb21893378219da10c44fc8"
+checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
 dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.61",
+ "syn 2.0.65",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.3.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f69089032567ffff4eada41c573fc43ff466c7db7c5688b2e7969584345581"
+checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
 dependencies = [
  "sha2",
  "walkdir",
@@ -3900,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -3971,22 +3972,22 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4003,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -4203,7 +4204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ff9eaf853dec4c8802325d8b6d3dffa86cc707fd7a1a4cdbf416e13b061787a"
 dependencies = [
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4280,7 +4281,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4293,7 +4294,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4330,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.61"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4348,7 +4349,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4434,22 +4435,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4552,21 +4553,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.12",
+ "toml_edit 0.22.13",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -4584,9 +4585,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.12"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
  "indexmap",
  "serde",
@@ -4594,6 +4595,12 @@ dependencies = [
  "toml_datetime",
  "winnow 0.6.8",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059d83cc991e7a42fc37bd50941885db0888e34209f8cfd9aab07ddec03bc9cf"
 
 [[package]]
 name = "typenum"
@@ -4622,7 +4629,7 @@ checksum = "ac73887f47b9312552aa90ef477927ff014d63d1920ca8037c6c1951eab64bb1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4984,7 +4991,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
  "wasm-bindgen-shared",
 ]
 
@@ -5006,7 +5013,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5348,7 +5355,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.65",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -384,6 +384,24 @@ def "nur hello" [] {
 
 I recommend reading about [`nu` modules](https://www.nushell.sh/book/modules.html) in the official `nu` documentation.
 
+### Low level `nur` usage
+
+When using your own commands as utilities and maybe even pack those into modules it may come in handy to
+run those commands one by one - either for debugging or to just get some small portion of your `nurfile`
+run in rare occasions.
+
+Do to this via your shell you can use `--commands`/`-c`, given the command `some-helper` from above you can
+for example only run this command by using `nur -c "some-helper"`. I personally sometimes use this to only
+run certain parts of my install/setup tasks to speed things up. Of course you only should ever do this when you
+absolutely know what you are doing.
+
+If you feel even more adventurous you may use `nur --enter-shell` to open up the `nu` shell powering `nur`
+with everything initializes. This is particularly useful for debugging your `nurfile` and should not be used
+for anything else. Note the shell will not use your normal `nu` shell setup, if you are using `nu` shell yourself
+outside of `nur`. This is due to the fact that `nur` will - by design - not read your global `env.nu` and
+`config.nu` to ensure `nur` works the same on every devs machine. Instead those files will only be project
+specific, see below.
+
 ### Provide `env.nu` and `config.nu` for project specific setup
 
 Like [with `nu`](https://www.nushell.sh/book/configuration.html) you can have your own environment

--- a/nur-tests/nurfile
+++ b/nur-tests/nurfile
@@ -90,6 +90,11 @@ def "nur test-sub-task-with-any-args" [] {
     std assert ((run-nur do-sub-task-with-any-args sub some random args) == "sub-ok")
 }
 
+def "nur test-running-commands" [] {
+    std assert ((run-nur --commands "print 'ok'") == "ok")
+    std assert ((run-nur --commands "print $nurcmd") == $nurcmd)
+}
+
 # Utils and other commands
 
 def is-windows [] {

--- a/scripts/nur-completions.bash
+++ b/scripts/nur-completions.bash
@@ -26,7 +26,7 @@ _comp_cmd_nur()
     then
         if [[ ${cur} == -* ]]
         then
-            opts=" -h --help --version --list --quiet --stdin"
+            opts=" -h --help -v --version -l --list -q --quiet --stdin -c --commands --enter-shell"
             COMPREPLY=( $( compgen -W "${opts}" -- "${cur}" ) )
             return 0
         else

--- a/scripts/nur-completions.nu
+++ b/scripts/nur-completions.nu
@@ -5,10 +5,12 @@ def "nu-complete nur task-names" [] {
 # nur - a taskrunner based on nu shell.
 export extern nur [
   --help(-h)  # Display the help message for this command
-  --version  # Output version number and exit
-  --list  # List available tasks and then just exit
-  --quiet  # Do not output anything but what the task produces
+  --version(-v)  # Output version number and exit
+  --list(-l)  # List available tasks and then just exit
+  --quiet(-q)  # Do not output anything but what the task produces
   --stdin  # Attach stdin to called nur task
+  --commands(-c)  # Run the given commands after nurfiles have been loaded
+  --enter-shell  # Enter a nu REPL shell after the nurfiles have been loaded (use only for debugging)
   task_name?: string@"nu-complete nur task-names"  # Name of the task to run (optional)
   ...args  # Parameters to the executed task
 ]

--- a/scripts/nur-completions.zsh
+++ b/scripts/nur-completions.zsh
@@ -14,11 +14,18 @@ _nur() {
     typeset -A opt_args
 
     _arguments -C \
+        '-h[Display the help message for this command]' \
         '--help[Display the help message for this command]' \
+        '-v[Output version number and exit]' \
         '--version[Output version number and exit]' \
+        '-l[List available tasks and then just exit]' \
         '--list[List available tasks and then just exit]' \
+        '-q[Do not output anything but what the task produces]' \
         '--quiet[Do not output anything but what the task produces]' \
         '--stdin[Attach stdin to called nur task]' \
+        '-c[Run the given commands after nurfiles have been loaded]' \
+        '--commands[Run the given commands after nurfiles have been loaded]' \
+        '--enter-shell[Enter a nu REPL shell after the nurfiles have been loaded (use only for debugging)]' \
         '::optional arg:_nur_tasks' \
         '*: :->args' \
         && ret=0

--- a/src/args.rs
+++ b/src/args.rs
@@ -288,6 +288,8 @@ mod tests {
         assert_eq!(nur_args.quiet_execution, false);
         assert_eq!(nur_args.attach_stdin, false);
         assert_eq!(nur_args.show_help, false);
+        assert!(nur_args.run_commands.is_none());
+        assert_eq!(nur_args.enter_shell, false);
     }
 
     #[test]
@@ -296,9 +298,6 @@ mod tests {
 
         let nur_args = parse_commandline_args("nur --list", &mut engine_state).unwrap();
         assert_eq!(nur_args.list_tasks, true);
-        assert_eq!(nur_args.quiet_execution, false);
-        assert_eq!(nur_args.attach_stdin, false);
-        assert_eq!(nur_args.show_help, false);
     }
 
     #[test]
@@ -306,10 +305,7 @@ mod tests {
         let mut engine_state = _create_minimal_engine_for_erg_parsing();
 
         let nur_args = parse_commandline_args("nur --quiet", &mut engine_state).unwrap();
-        assert_eq!(nur_args.list_tasks, false);
         assert_eq!(nur_args.quiet_execution, true);
-        assert_eq!(nur_args.attach_stdin, false);
-        assert_eq!(nur_args.show_help, false);
     }
 
     #[test]
@@ -317,10 +313,7 @@ mod tests {
         let mut engine_state = _create_minimal_engine_for_erg_parsing();
 
         let nur_args = parse_commandline_args("nur --stdin", &mut engine_state).unwrap();
-        assert_eq!(nur_args.list_tasks, false);
-        assert_eq!(nur_args.quiet_execution, false);
         assert_eq!(nur_args.attach_stdin, true);
-        assert_eq!(nur_args.show_help, false);
     }
 
     #[test]
@@ -328,9 +321,24 @@ mod tests {
         let mut engine_state = _create_minimal_engine_for_erg_parsing();
 
         let nur_args = parse_commandline_args("nur --help", &mut engine_state).unwrap();
-        assert_eq!(nur_args.list_tasks, false);
-        assert_eq!(nur_args.quiet_execution, false);
-        assert_eq!(nur_args.attach_stdin, false);
         assert_eq!(nur_args.show_help, true);
+    }
+
+    #[test]
+    fn test_parse_commandline_args_commands() {
+        let mut engine_state = _create_minimal_engine_for_erg_parsing();
+
+        let nur_args =
+            parse_commandline_args("nur --commands 'some_command'", &mut engine_state).unwrap();
+        assert!(nur_args.run_commands.is_some());
+        assert_eq!(nur_args.run_commands.unwrap().item, "some_command");
+    }
+
+    #[test]
+    fn test_parse_commandline_args_enter_shell() {
+        let mut engine_state = _create_minimal_engine_for_erg_parsing();
+
+        let nur_args = parse_commandline_args("nur --enter-shell", &mut engine_state).unwrap();
+        assert_eq!(nur_args.enter_shell, true);
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,21 +2,22 @@ use crate::commands::Nur;
 use crate::errors::{NurError, NurResult};
 use crate::names::NUR_NAME;
 use nu_engine::{get_full_help, CallExt};
-use nu_parser::escape_for_script_arg;
 use nu_parser::parse;
-use nu_protocol::report_error;
+use nu_parser::{escape_for_script_arg, escape_quote_string};
+use nu_protocol::ast::Expression;
 use nu_protocol::{
     ast::Expr,
     engine::{Command, EngineState, Stack, StateWorkingSet},
     ShellError,
 };
+use nu_protocol::{report_error, Spanned};
 use nu_utils::stdout_write_all_and_flush;
 
 pub(crate) fn is_safe_taskname(name: &str) -> bool {
     // This is basically similar to string_should_be_quoted
     // in nushell/crates/nu-parser/src/deparse.rs:1,
     // BUT may change as the requirements are different.
-    // Also I added "#" and "^", as seem in
+    // Also I added "#" and "^", as seen in
     // nushell/crates/nu-parser/src/parse_keywords.rs:175
     !name.starts_with('$')
         && !(name.chars().any(|c| {
@@ -55,16 +56,17 @@ pub(crate) fn gather_commandline_args(
             break;
         }
 
-        // let flag_value = match arg.as_ref() {
-        //     // "--some-file" => args.next().map(|a| escape_quote_string(&a)),
-        //     _ => None,
-        // };
+        let flag_value = match arg.as_ref() {
+            // "--some-file" => args.next().map(|a| escape_quote_string(&a)),
+            "--commands" | "-c" => args_iter.next().map(|a| escape_quote_string(a)),
+            _ => None,
+        };
 
         args_to_nur.push(arg.clone());
 
-        // if let Some(flag_value) = flag_value {
-        //     args_to_nur.push(flag_value);
-        // }
+        if let Some(flag_value) = flag_value {
+            args_to_nur.push(flag_value);
+        }
     }
 
     if has_task_call {
@@ -105,11 +107,13 @@ pub(crate) fn parse_commandline_args(
     // We should have a successful parse now
     if let Some(pipeline) = block.pipelines.first() {
         if let Some(Expr::Call(call)) = pipeline.elements.first().map(|e| &e.expr.expr) {
-            // let config_file = call.get_flag_expr("config");
+            // let config_file = call.get_flag_expr("some-flag");
             let list_tasks = call.has_flag(engine_state, &mut stack, "list")?;
             let quiet_execution = call.has_flag(engine_state, &mut stack, "quiet")?;
             let attach_stdin = call.has_flag(engine_state, &mut stack, "stdin")?;
             let show_help = call.has_flag(engine_state, &mut stack, "help")?;
+            let run_commands = call.get_flag_expr("commands");
+            let enter_shell = call.has_flag(engine_state, &mut stack, "enter-shell")?;
             #[cfg(feature = "debug")]
             let debug_output = call.has_flag(engine_state, &mut stack, "debug")?;
 
@@ -122,11 +126,36 @@ pub(crate) fn parse_commandline_args(
                 std::process::exit(0);
             }
 
+            fn extract_contents(
+                expression: Option<&Expression>,
+            ) -> Result<Option<Spanned<String>>, ShellError> {
+                if let Some(expr) = expression {
+                    let str = expr.as_string();
+                    if let Some(str) = str {
+                        Ok(Some(Spanned {
+                            item: str,
+                            span: expr.span,
+                        }))
+                    } else {
+                        Err(ShellError::TypeMismatch {
+                            err_message: "string".into(),
+                            span: expr.span,
+                        })
+                    }
+                } else {
+                    Ok(None)
+                }
+            }
+
+            let run_commands = extract_contents(run_commands)?;
+
             return Ok(NurArgs {
                 list_tasks,
                 quiet_execution,
                 attach_stdin,
                 show_help,
+                run_commands,
+                enter_shell,
                 #[cfg(feature = "debug")]
                 debug_output,
             });
@@ -151,6 +180,8 @@ pub(crate) struct NurArgs {
     pub(crate) quiet_execution: bool,
     pub(crate) attach_stdin: bool,
     pub(crate) show_help: bool,
+    pub(crate) run_commands: Option<Spanned<String>>,
+    pub(crate) enter_shell: bool,
     #[cfg(feature = "debug")]
     pub(crate) debug_output: bool,
 }

--- a/src/commands/nur.rs
+++ b/src/commands/nur.rs
@@ -23,19 +23,19 @@ impl Command for Nur {
             .switch(
                 "quiet",
                 "Do not output anything but what the task produces",
-                None,
+                Some('q'),
             )
             .switch("stdin", "Attach stdin to called nur task", None)
             .named(
                 "commands",
                 SyntaxShape::String,
-                "run the given commands and then exit",
+                "Run the given commands after nurfiles have been loaded",
                 Some('c'),
             )
             .switch(
                 "enter-shell",
-                "enter nu shell with nur being setup (use this for debugging)",
-                Some('e'),
+                "Enter a nu REPL shell after the nurfiles have been loaded (use only for debugging)",
+                None,
             )
             .optional(
                 "task name",

--- a/src/commands/nur.rs
+++ b/src/commands/nur.rs
@@ -18,14 +18,25 @@ impl Command for Nur {
 
         signature = signature
             .usage("nur - a taskrunner based on nu shell.")
-            .switch("version", "Output version number and exit", None)
-            .switch("list", "List available tasks and then just exit", None)
+            .switch("version", "Output version number and exit", Some('v'))
+            .switch("list", "List available tasks and then just exit", Some('l'))
             .switch(
                 "quiet",
                 "Do not output anything but what the task produces",
                 None,
             )
             .switch("stdin", "Attach stdin to called nur task", None)
+            .named(
+                "commands",
+                SyntaxShape::String,
+                "run the given commands and then exit",
+                Some('c'),
+            )
+            .switch(
+                "enter-shell",
+                "enter nu shell with nur being setup (use this for debugging)",
+                Some('e'),
+            )
             .optional(
                 "task name",
                 SyntaxShape::String,
@@ -40,7 +51,7 @@ impl Command for Nur {
 
         #[cfg(feature = "debug")]
         {
-            signature = signature.switch("debug", "Show debug details", None);
+            signature = signature.switch("debug", "Show debug details", Some('d'));
         }
 
         signature

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,14 +1,15 @@
 use crate::args::{is_safe_taskname, parse_commandline_args, NurArgs};
+use crate::errors::NurError::EnteredShellError;
 use crate::errors::{NurError, NurResult};
 use crate::names::{
     NUR_ENV_NUR_TASK_CALL, NUR_ENV_NUR_TASK_NAME, NUR_ENV_NUR_VERSION, NUR_ENV_NU_LIB_DIRS,
     NUR_NAME, NUR_VAR_CONFIG_DIR, NUR_VAR_DEFAULT_LIB_DIR, NUR_VAR_PROJECT_PATH, NUR_VAR_RUN_PATH,
-    NUR_VAR_TASK_NAME,
+    NUR_VAR_TASK_NAME, NUSHELL_FOLDER,
 };
 use crate::nu_version::NU_VERSION;
 use crate::scripts::{get_default_nur_config, get_default_nur_env};
 use crate::state::NurState;
-use nu_cli::gather_parent_env_vars;
+use nu_cli::{evaluate_repl, gather_parent_env_vars};
 use nu_engine::get_full_help;
 use nu_protocol::ast::Block;
 use nu_protocol::engine::{Command, Stack, StateWorkingSet};
@@ -419,6 +420,20 @@ impl NurEngine {
         );
 
         let _ = std::panic::catch_unwind(move || stdout_write_all_and_flush(full_help));
+    }
+
+    pub(crate) fn run_repl(&mut self) -> NurResult<()> {
+        match evaluate_repl(
+            &mut self.engine_state,
+            self.stack.clone(),
+            NUSHELL_FOLDER,
+            None,
+            None,
+            std::time::Instant::now(),
+        ) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(EnteredShellError()),
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,6 +33,10 @@ pub enum NurError {
     #[error("Could not find nurfile in path and parents")]
     #[diagnostic()]
     NurfileNotFound(),
+
+    #[error("Entered shell did raise an error")]
+    #[diagnostic()]
+    EnteredShellError(),
 }
 
 impl From<std::io::Error> for NurError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,27 +106,16 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
 
     // Show help if no task call was found
     // (error exit if --help was not passed)
-    if !nur_engine.state.has_task_call {
+    if !nur_engine.state.has_task_call
+        && parsed_nur_args.run_commands.is_none()
+        && !parsed_nur_args.enter_shell
+    {
         nur_engine.print_help(&Nur);
         if parsed_nur_args.show_help {
             std::process::exit(0);
         } else {
             std::process::exit(1);
         }
-    }
-
-    // Ensure we have a task name
-    if nur_engine.state.task_name.is_none() {
-        return Err(miette::ErrReport::from(NurError::TaskNotFound(
-            nur_engine.state.task_call.join(" "),
-        )));
-    }
-    #[cfg(feature = "debug")]
-    if parsed_nur_args.debug_output {
-        eprintln!(
-            "full task name: {}",
-            nur_engine.state.task_name.clone().unwrap()
-        );
     }
 
     // Handle help
@@ -170,13 +159,17 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
 
     // Execute the task
     let exit_code: i64;
-    let full_task_call = nur_engine.state.task_call.join(" ");
+    let run_command = if parsed_nur_args.run_commands.is_some() {
+        parsed_nur_args.run_commands.clone().unwrap().item
+    } else {
+        nur_engine.state.task_call.join(" ")
+    };
     #[cfg(feature = "debug")]
     if parsed_nur_args.debug_output {
-        eprintln!("full task call: {}", full_task_call);
+        eprintln!("full command call: {}", run_command);
     }
     if parsed_nur_args.quiet_execution {
-        exit_code = nur_engine.eval_and_print(full_task_call, input)?;
+        exit_code = nur_engine.eval_and_print(run_command, input)?;
 
         #[cfg(feature = "debug")]
         if parsed_nur_args.debug_output {
@@ -188,9 +181,13 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
             "Project path: {}",
             nur_engine.state.project_path.to_str().unwrap()
         );
-        println!("Executing task: {}", nur_engine.get_short_task_name());
+        if parsed_nur_args.run_commands.is_some() {
+            println!("Running command: {}", run_command);
+        } else {
+            println!("Executing task: {}", nur_engine.get_short_task_name());
+        }
         println!();
-        exit_code = nur_engine.eval_and_print(full_task_call, input)?;
+        exit_code = nur_engine.eval_and_print(run_command, input)?;
         #[cfg(feature = "debug")]
         if parsed_nur_args.debug_output {
             println!("Exit code {:?}", exit_code);
@@ -211,12 +208,13 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
             );
         } else {
             println!(
-                "{}Task execution failed{}",
+                "{}Task execution failed (exit code: {}){}",
                 if use_color {
                     Color::Red.prefix().to_string()
                 } else {
                     String::from("")
                 },
+                exit_code,
                 if use_color {
                     Color::Red.suffix().to_string()
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,12 @@ fn main() -> Result<ExitCode, miette::ErrReport> {
     if parsed_nur_args.debug_output {
         eprintln!("full command call: {}", run_command);
     }
-    if parsed_nur_args.quiet_execution {
+    if parsed_nur_args.enter_shell {
+        exit_code = match nur_engine.run_repl() {
+            Ok(_) => 0,
+            Err(_) => 1,
+        }
+    } else if parsed_nur_args.quiet_execution {
         exit_code = nur_engine.eval_and_print(run_command, input)?;
 
         #[cfg(feature = "debug")]

--- a/src/names.rs
+++ b/src/names.rs
@@ -22,3 +22,6 @@ pub(crate) const NUR_VAR_DEFAULT_LIB_DIR: &str = "default-lib-dir";
 // nurfile names
 pub(crate) const NUR_FILE: &str = "nurfile";
 pub(crate) const NUR_LOCAL_FILE: &str = "nurfile.local";
+
+// nu shell consts
+pub(crate) const NUSHELL_FOLDER: &str = "nushell"; // nu-cli -> config_files.rs

--- a/src/names.rs
+++ b/src/names.rs
@@ -24,4 +24,4 @@ pub(crate) const NUR_FILE: &str = "nurfile";
 pub(crate) const NUR_LOCAL_FILE: &str = "nurfile.local";
 
 // nu shell consts
-pub(crate) const NUSHELL_FOLDER: &str = "nushell"; // nu-cli -> config_files.rs
+pub(crate) const NUSHELL_FOLDER: &str = "nushell"; // nu-cli -> config_files.rs, used for REPL


### PR DESCRIPTION
# Description

Add `--commands`/`-c` to directly run commands from `nur` cli.

Also adds `--enter-shell` to open up a nu shell with the whole `nur` setup being done, use only for debugging.

Also updates the shell completion scripts.
